### PR TITLE
Replace abandoned malkusch/php-index with own hosted version of the same package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,12 @@
     "autoload": {
         "files": ["autoloader/autoloader.php"]
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/mensler/php-index.git"
+        }
+    ],
     "require": {
         "php": ">=7.0.0",
         "malkusch/php-index": "~0.1"


### PR DESCRIPTION
To make use of the own hosted version of `malkusch/php-index` the following steps are required:

1. push source of `malkusch/php-index` to `https://github.com/mensler/php-index.git`
2. make a release of `mensler/php-index` and tag it with `0.1.1`
3. merge this PR
4. release a new version of `mensler/bav`